### PR TITLE
added styling for inline code quote

### DIFF
--- a/docs/.vuepress/styles/theme.styl
+++ b/docs/.vuepress/styles/theme.styl
@@ -73,6 +73,7 @@ p a code
   color $accentColor
 
 
+
 kbd
   background #eee
   border solid 0.15rem #ddd
@@ -195,6 +196,14 @@ th, td
 .language-text
   border-radius 6px
   font-size 12px
+
+:not(.language-text) > code
+  color: #4b6c89
+  padding: 0.25rem 0.5rem
+  margin: 0
+  font-size: .85em
+  background-color: rgba(27,31,35,.05)
+  border-radius: 3px
 
 @media (max-width: $mobileBreakpoint)
   .content:not(.custom)


### PR DESCRIPTION
Indented code blocks are nested under a parent of the class: "language-text"
Inline code blocks are not, so I used this selector to add styling to them:

:not(.language-text) > code