### PR TITLE
Fix anchor bug

### DIFF
--- a/docs/.vuepress/theme/sidebar/Sidebar.vue
+++ b/docs/.vuepress/theme/sidebar/Sidebar.vue
@@ -76,7 +76,7 @@ const isInViewport = (element) => {
   return (
     rect.top >= 0 &&
     rect.left >= 0 &&
-    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.bottom <= (window.innerHeight / 2 || document.documentElement.clientHeight / 2) &&
     rect.right <= (window.innerWidth || document.documentElement.clientWidth)
   );
 };


### PR DESCRIPTION
fixed a bug in `` function in `docs/.vuepress/theme/sidebar/Sidebar.vue` that was causing the wrong anchor to be highlighted when there are two close anchors.