### PR TITLE
CLOS-1442: Emphasize that license is necessary for ELevate

### DIFF
--- a/docs/shared/elevate/README.md
+++ b/docs/shared/elevate/README.md
@@ -424,6 +424,8 @@ sudo yum install https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.
 
 3. Install leapp packages and migration data for the CloudLinux OS.
 
+:::tip Note that [a valid license](/shared/cloudlinux_installation/#license-activation) must be present for installation to work :::
+
 ```
 sudo yum install -y leapp-upgrade leapp-data-cloudlinux
 ```


### PR DESCRIPTION
It's not entirely clear from an installation instruction that ELevate requires proper license to be present or it will be impossible to install it as some subscription-based RPM repos won't be available.