### PR TITLE
Add the location of the MySQL Governor error log

### DIFF
--- a/docs/shared/cloudlinux_os_components/README.md
+++ b/docs/shared/cloudlinux_os_components/README.md
@@ -3709,7 +3709,8 @@ service db_governor restart
 
 <span class="notranslate"> **Error_log** </span>
 
-<span class="notranslate"> MySQL Governor </span> error log is used to track any problems that <span class="notranslate"> MySQL Governor </span> might have
+<span class="notranslate"> MySQL Governor </span> error log is used to track any problems that <span class="notranslate"> MySQL Governor </span> might encounter.
+Error log is located in <span class="notranslate"> /var/log/dbgovernor-error.log </span>
 
 <span class="notranslate"> **Restrict_log** </span>
 


### PR DESCRIPTION
Previously was missing from the doc.