### PR TITLE
Update installation instructions for Apache2Nginx

### DIFF
--- a/docs/shared/apache2nginx/README.md
+++ b/docs/shared/apache2nginx/README.md
@@ -17,7 +17,8 @@ Apache2Nginx is supported on cPanel servers only, running CloudLinux OS 8 and la
 To use Apache2Nginx, first install the `apache2nginx` package:
 
 ```
-dnf --enablerepo=cl-ea4-testing,cloudlinux-updates-testing install apache2nginx
+dnf config-manager --set-enabled cl-ea4-testing
+dnf --enablerepo=cloudlinux-updates-testing install apache2nginx
 ```
 
 ## Convert to NGINX hosting


### PR DESCRIPTION
The previous instructions for installing the `apache2nginx` package were concise but error-prone. The new commit provides an extra step for enabling 'cl-ea4-testing' repository which is required for a hassle-free installation of the Apache2Nginx tool.