### PR TITLE
Remove unnecessary command from Apache2Nginx README

### DIFF
--- a/docs/shared/apache2nginx/README.md
+++ b/docs/shared/apache2nginx/README.md
@@ -17,7 +17,6 @@ Apache2Nginx is supported on cPanel servers only, running CloudLinux OS 8 and la
 To use Apache2Nginx, first install the `apache2nginx` package:
 
 ```
-dnf config-manager --set-enabled cl-ea4-testing
 dnf --enablerepo=cloudlinux-updates-testing install apache2nginx
 ```
 


### PR DESCRIPTION
The commit removes a command from the installation instructions of Apache2Nginx in the documentation. This command is not needed anymore, making the installation process simpler and cleaner.