### PR TITLE
Add safety tip to Apache2NGINX README

### DIFF
--- a/docs/shared/apache2nginx/README.md
+++ b/docs/shared/apache2nginx/README.md
@@ -38,6 +38,11 @@ After conversion is complete, no further action is required.
 The monitoring subsystem, when detecting a change to an `.htaccess` runs conversions to NGINX configuration.
 So you can continue using `.htaccess` files as usual.
 
+:::tip  
+Do not attempt to stop the Apache service or remove Apache packages after switching to NGINX.
+The Apache service provides a safety net for websites that cannot be converted to NGINX.
+:::
+
 ## Switch back to Apache hosting
 
 To switch back to Apache, run:


### PR DESCRIPTION
This commit adds a tip to the Apache2NGINX README warning users not to disable Apache services after switching over to NGINX. Recognizing that some websites may not convert well, it clarifies that Apache serves as a fallback safety net for such cases.