### PR TITLE
Introduction document corrections

### DIFF
--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -27,21 +27,21 @@
 
 \* Limits are disabled by default.
 
-\** Python/Node.js/Ruby Selectors are available only for cPanel, DirectAdmin servers, and servers with custom panel with own integration.
+\** Python/Node.js/Ruby Selectors are available only for cPanel, DirectAdmin servers, and servers with custom panels with their own integration.
 
 ### CloudLinux OS Solo
-CloudLinux OS Solo is designed for installation on VPS or VDS servers. 
-This edition has major difference against all other, so you should look for the detailed docs 
+CloudLinux OS Solo is designed for installation on VPS or VDS servers.
+This edition has major differences compared to all others, so please make sure to carefully examine the feature table to see if it is suitable for you
 [here](/introduction/).
 
 
 ### CloudLinux OS Admin
 
-CloudLinux OS Admin is designed for shared hosting providers who want to flawlessly migrate their 
-big shared hosting customer to individual VPS with same CloudLinux features as on Shared hosting. 
-At the same time you will be able to separate such a user's websites if necessary and isolate them 
-with CageFS for efficient and extra security.
-Also it may be suitable for a little server with less than 5 customers on it.
+CloudLinux OS Admin is designed for shared hosting providers who want to flawlessly migrate their
+big shared hosting customer to individual VPS with same CloudLinux features as on Shared hosting.
+At the same time you will be able to separate such a user's websites if necessary and isolate them
+with CageFS for efficient extra security.
+Also it may be suitable for a small server with less than 5 customers on it.
 
 Most of the features of CloudLinux OS Shared are available in this edition, with a small differences:
 
@@ -51,16 +51,16 @@ Most of the features of CloudLinux OS Shared are available in this edition, with
 
 ### CloudLinux OS Shared (Pro)
 
-CloudLinux OS Shared is designed for shared hosting providers. 
-It isolates each customer into a separate “Lightweight Virtualized Environment” (LVE), 
-which allocates and limits server resources, like memory, CPU and the number of simultaneous connections, 
-for each web hosting tenant. This ensures that tenants cannot jeopardize the stability of your servers, 
-causing all sites to slow down or even come to a halt. CloudLinux OS Shared also “cages” tenants from one another 
-to avoid security breaches. This way, unstable scripts or malware are not able to sprawl across your customer sites, 
+CloudLinux OS Shared is designed for shared hosting providers.
+It isolates each customer into a separate “Lightweight Virtualized Environment” (LVE),
+which allocates and limits server resources, like memory, CPU and the number of simultaneous connections,
+for each web hosting tenant. This ensures that tenants cannot jeopardize the stability of your servers,
+causing all sites to slow down or even come to a halt. CloudLinux OS Shared also “cages” tenants from one another
+to avoid security breaches. This way, unstable scripts or malware are not able to sprawl across your customer sites,
 causing severe harm.
 
-Purchasing CloudLinux OS Shared Pro license extends your CloudLinux OS Shared 
-functionality with even more useful [features](/shared-pro/introduction/). 
+Purchasing CloudLinux OS Shared Pro license extends your CloudLinux OS Shared
+functionality with even more useful [features](/shared-pro/introduction/).
 
 
 ## CloudLinux OS components
@@ -68,17 +68,17 @@ functionality with even more useful [features](/shared-pro/introduction/).
 **CloudLinux Manager**
 
 LVE is a Lightweight Virtualized Environment.
-CloudLinux Manager allows you to maintain fine-tuned control over your resources, 
-including CPU, IO rate, memory, inodes, numbers of processes, and concurrent connections, 
+CloudLinux Manager allows you to maintain fine-tuned control over your resources,
+including CPU, IO rate, memory, inodes, numbers of processes, and concurrent connections,
 that any single account can use. Now you can limit resource abuse, while allowing good customers to use what they need.
 
 [See more](/shared/lve_manager/).
 
 **CageFS**
 
-CageFS is a virtualized, per-user file system that uniquely encapsulates each customer, 
-preventing users from seeing each other and viewing sensitive information. CageFS prevents a large number of attacks, 
-including most privilege escalation and information disclosure attacks. It is completely transparent to your customers, 
+CageFS is a virtualized, per-user file system that uniquely encapsulates each customer,
+preventing users from seeing each other and viewing sensitive information. CageFS prevents a large number of attacks,
+including most privilege escalation and information disclosure attacks. It is completely transparent to your customers,
 without any need for them to change their scripts.
 
 [See more](/shared/cloudlinux_os_components/#cagefs).
@@ -86,7 +86,7 @@ without any need for them to change their scripts.
 **MySQL Governor**
 
 :::tip Note
-This component is not available in CloudLinux OS Admin edition.
+This component is not available in the CloudLinux OS Admin edition.
 :::
 
 MySQL Governor tracks CPU and disk IO usage for every user in real time and throttles MySQL queries by using LVE limits. By using the [dbtop](/command-line_tools/#dbtop) utility, it is possible to see the database usage on a per-customer basis, ensuring that the system admin always know what is going on.
@@ -95,53 +95,53 @@ MySQL Governor tracks CPU and disk IO usage for every user in real time and thro
 
 **PHP Selector**
 
-PHP Selector allows end users to select the specific version of PHP they need. It allows ultimate flexibility by offering all 
+PHP Selector allows end users to select the specific version of PHP they need. It allows ultimate flexibility by offering all
 popular versions of PHP, with more than 120 PHP extensions to choose from.
 
 [See more](/shared/cloudlinux_os_components/#php-selector).
 
 **Ruby Selector**
 
-Ruby Selector allows end users to choose the Ruby version for applications and install additional modules 
+Ruby Selector allows end users to choose the Ruby version for applications and install additional modules
 to the application environment. Ruby Selector uses `mod_passenger` for delivering optimum performance.
 
 [See more](/shared/cloudlinux_os_components/#ruby-selector).
 
 **Python Selector**
 
-Python Selector allows end users to choose the Python version for applications and install additional modules. 
+Python Selector allows end users to choose the Python version for applications and install additional modules.
 Python Selector uses `mod_passenger` to get the best performance from Python applications.
 
 [See more](/shared/cloudlinux_os_components/#python-selector).
 
 **Node.js Selector**
 
-Node.js Selector is a CloudLinux OS Shared component that allows each user to easily create Node.js applications, 
-choose Node.js version and other parameters for applications based on their needs.
+Node.js Selector is a CloudLinux OS Shared component that allows each user to easily create Node.js applications,
+choose Node.js versions and other parameters for applications based on their needs.
 
 [See more](/shared/cloudlinux_os_components/#node-js-selector).
 
 **Apache mod_lsapi PRO**
 
-Mod_lsapi PRO is the fastest PHP handler for Apache. It is a drop-in replacement for SuPHP, FCGID, RUID2, and ITK. 
+Mod_lsapi PRO is the fastest PHP handler for Apache. It is a drop-in replacement for SuPHP, FCGID, RUID2, and ITK.
 It has a low memory footprint and understands `.htaccess` PHP directives.
 
 [See more](/shared/cloudlinux_os_components/#apache-mod-lsapi-pro).
 
 **Reseller limits**
 
-Reseller limits is a feature that allows hosters to set limits for the resources each Reseller can operate with. 
-Server admin also provides controls on what resources each end user will have. Reseller limits set by a hoster 
+Reseller limits is a feature that allows hosters to set limits for the resources each Reseller can operate with.
+The server admin also provides controls on what resources each end user will have. Reseller limits set by a hoster
 limit the total amount of resources resellers’ end users can consume altogether.
 
-When a hoster has set reseller limits for the particular reseller he provides the reseller with an ability to 
+When a hoster has set reseller limits for the particular reseller he provides the reseller with an ability to
 set limits for his end users within the Reseller Interface.
 
 [See more](/shared/cloudlinux_os_components/#reseller-limits).
 
 **LVE-stats 2**
 
-VE-stats 2 collects LVE usage statistics (CPU, memory, disk space usage) 
+LVE-stats 2 collects LVE usage statistics (CPU, memory, disk space usage),
 and allows to collect the usage data.
 
 [See more](/shared/cloudlinux_os_components/#lve-stats-2).
@@ -164,7 +164,7 @@ If you have a server with cPanel + CloudLinux already installed via the experime
 
 ## CloudLinux OS life cycle
 
-CloudLinux OS follows the life cycle policy of RHEL. 
+CloudLinux OS follows the life cycle policy of RHEL.
 Using a supported operating system is critical to maintaining a stable server environment.
 
 Currently, the following versions are available and supported:

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -162,22 +162,6 @@ Starting from v11.116.0.1, cPanel is fully integrated with CloudLinux 9 (9.2+), 
 If you have a server with cPanel + CloudLinux already installed via the experimental flag `--experimental-os=almalinux-9.2`, as described here, it is highly recommended to reinstall the server from scratch to avoid unexpected behavior.
 :::
 
-:::tip Note!
-While the cPanel version 11.116.0.1 is not in the Stable Release, use the following instructions to install cPanel on the latest versions of CloudLinux 9. 
-:::
-
-1. Update the `/etc/cpupdate.conf` as described here, and set the config value:  
-
-```
-CPANEL=current
-```
-
-2. Start the cPanel installation process:
-
-```
-cd /home && curl -o latest -L https://securedownloads.cpanel.net/latest && sh latest
-```
-
 ## CloudLinux OS life cycle
 
 CloudLinux OS follows the life cycle policy of RHEL. 


### PR DESCRIPTION
Trim trailing whitespaces and rephrase some lines to be more correct.

Also remove the instruction regarding installation of cPanel 116.
cPanel 116 has already entered stable release, and as such, this information is no longer needed.