### PR TITLE
Add section about NGINX configuration in README

### DIFF
--- a/docs/shared/apache2nginx/README.md
+++ b/docs/shared/apache2nginx/README.md
@@ -89,3 +89,15 @@ apache2nginx list-proxied
 ```
 
 This command lists all websites that are forced to be served by Apache and the reason for that.
+
+## Other notes
+
+Apache2Nginx automatically converts `.htaccess` files to NGINX configuration, stored under the directory `/etc/nginx`
+as `apache2nginx.conf` and files prefixed with `apache2nginx-`.
+
+Please don't modify these files manually, as they will be overwritten by the monitoring subsystem.
+
+Instead, if you want to augment the NGINX configuration, you can do any of the following:
+
+* Work with your `.htaccess` files like usually, and let Apache2Nginx automatically convert them to respective NGINX configuration
+* Add files according to `ea-nginx` files conventions. Please refer to the [cPanel documentation](https://docs.cpanel.net/knowledge-base/web-services/nginx-with-reverse-proxy/).


### PR DESCRIPTION
The commit adds a new section in the README file under the Apache2Nginx directory. This section provides information about how Apache2Nginx automatically converts `.htaccess` files to NGINX configuration, and warns against manually modifying these configuration files, suggesting alternatives instead.