### PR TITLE
TCR-499 Rename the "CLN" to "CLN - CloudLinux Licenses"

### DIFF
--- a/docs/.vuepress/config-client/documents.ts
+++ b/docs/.vuepress/config-client/documents.ts
@@ -25,7 +25,7 @@ export default [
         link: "/shared-pro/accelerate-wp/",
     },
     {
-        title: "CLN",
+        title: "CLN - CloudLinux Licenses",
         description: "CLN is a CloudLinux Network designed to easily manage your licenses of CloudLinux products and services by means of a user-friendly interface.",
         link: "/cln/introduction/",
     },


### PR DESCRIPTION
TCR-499 Rename the "CLN" to "CLN - CloudLinux Licenses" in the doc section dropdown and the doc homepage