### PR TITLE
 [TCR-566] Support Badge and deprecated HTML elements as custom elements in VuePress

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -14,7 +14,22 @@ export default defineUserConfig({
   bundler: viteBundler({
     viteOptions: {
       ssr: {
-        noExternal: ["vue-select", "vue-multiselect"],
+        noExternal: ['vue-select', 'vue-multiselect'],
+      },
+    },
+    vuePluginOptions: {
+      template: {
+        compilerOptions: {
+          isCustomElement: (tag) => {
+            // List of deprecated HTML tags to treat as custom elements
+            // Add any other custom elements to this list 
+            const customElements = [
+              'Badge', 'center', 'font', 'big', 'small', 'strike', 'tt', 
+              'marquee', 'blink', 'applet', 'frameset', 'frame', 'dir',
+            ];
+            return customElements.includes(tag);
+          },
+        },
       },
     },
   }),


### PR DESCRIPTION
### docs/.vuepress/config.ts: Support Badge and deprecated HTML elements as custom elements in VuePress
- Added `isCustomElement` configuration to recognize the `<Badge>` component.
- Included support for deprecated HTML tags as custom elements:
  - `<center>`, `<font>`, `<big>`, `<small>`, `<strike>`, `<tt>`, `<marquee>`, `<blink>`, `<applet>`, `<frameset>`, `<frame>`, `<dir>`
- Prevented Vue compiler warnings by treating these tags and the `<Badge>` component as custom elements.
- Improved compatibility with legacy HTML content and custom components in markdown.