### PR TITLE
Correct the displayed period of collected requests availability in UI

### DIFF
--- a/docs/cloudlinuxos/shared-pro/README.md
+++ b/docs/cloudlinuxos/shared-pro/README.md
@@ -2022,7 +2022,7 @@ A tracing task can have the following statuses:
 #### Collected requests for tracing task
 
 :::warning Warning!
-Collected requests are available in the UI for two weeks.
+Collected requests are available in the UI for 30 days.
 :::
 
 Click ![](/images/cloudlinuxos/shared-pro/x-ray/XRayView.webp) to open a list of collected requests.


### PR DESCRIPTION

Fix wrong message about period for avalability of requests in UI. Wrong message:
"Collected requests are available in the UI for two weeks."

Correct message:
"Collected requests are available in the UI for 30 days."