### PR TITLE
CLOS-4108: Rename 'Website isolation' to 'CloudLinux Isolates' in CLI output code examples

### DIFF
--- a/docs/cloudlinuxos/isolates/README.md
+++ b/docs/cloudlinuxos/isolates/README.md
@@ -141,7 +141,7 @@ Enables the CloudLinux Isolates feature server-wide in "Allow All" mode. All use
 
 ```
 # cagefsctl --site-isolation-allow-all
-Website isolation was allowed for all users.
+CloudLinux Isolates was allowed for all users.
 ```
 
 **Notes:**
@@ -166,7 +166,7 @@ Disables the CloudLinux Isolates feature server-wide and switches to "Deny All" 
 
 ```
 # cagefsctl --site-isolation-deny-all
-Website isolation was denied for all users.
+CloudLinux Isolates was denied for all users.
 ```
 
 **Warning:** This command will:
@@ -210,10 +210,10 @@ Allows CloudLinux Isolates for one or more specific users.
 
 ```
 # cagefsctl --site-isolation-allow john
-Website isolation was allowed for user(s): john
+CloudLinux Isolates was allowed for user(s): john
 
 # cagefsctl --site-isolation-allow john jane
-Website isolation was allowed for user(s): john, jane
+CloudLinux Isolates was allowed for user(s): john, jane
 ```
 
 ***
@@ -241,7 +241,7 @@ Denies CloudLinux Isolates for one or more specific users and disables all their
 
 ```
 # cagefsctl --site-isolation-deny john
-Website isolation was denied for user(s): john
+CloudLinux Isolates was denied for user(s): john
 ```
 
 **Notes:**
@@ -269,7 +269,7 @@ Toggles the isolation user mode between "Allow All" and "Deny All" without modif
 
 ```
 # cagefsctl --site-isolation-toggle-mode
-Website isolation user mode toggled to 'deny_all'.
+CloudLinux Isolates user mode toggled to 'deny_all'.
 ```
 
 **Notes:**
@@ -301,11 +301,11 @@ Enables CloudLinux Isolates for one or more specified domains.
 
 ```
 # cagefsctl --site-isolation-enable example.com
-Website isolation was enabled for domain(s),
+CloudLinux Isolates was enabled for domain(s),
 example.com
 
 # cagefsctl --site-isolation-enable site1.com site2.com
-Website isolation was enabled for domain(s),
+CloudLinux Isolates was enabled for domain(s),
 site1.com,site2.com
 ```
 
@@ -346,7 +346,7 @@ Disables CloudLinux Isolates for one or more specified domains.
 
 ```
 # cagefsctl --site-isolation-disable example.com
-Website isolation was disabled for domain(s),
+CloudLinux Isolates was disabled for domain(s),
 example.com
 ```
 
@@ -385,11 +385,11 @@ Lists all users and domains that have CloudLinux Isolates enabled.
 ```
 # cagefsctl --site-isolation-list
 
-Domains with enabled website isolation for user john:
+Domains with enabled CloudLinux Isolates for user john:
 example.com
 mysite.org
 
-Domains with enabled website isolation for user jane:
+Domains with enabled CloudLinux Isolates for user jane:
 shop.example.com
 ```
 
@@ -398,7 +398,7 @@ shop.example.com
 ```
 # cagefsctl --site-isolation-list john
 
-Domains with enabled website isolation for user john:
+Domains with enabled CloudLinux Isolates for user john:
 example.com
 mysite.org
 ```
@@ -407,7 +407,7 @@ mysite.org
 
 ```
 # cagefsctl --site-isolation-list
-No users with enabled Website isolation
+No users with enabled CloudLinux Isolates
 ```
 
 ***
@@ -430,7 +430,7 @@ Regenerates the CloudLinux Isolates configuration for specified users. Use this 
 
 ```
 # cagefsctl --site-isolation-regenerate john jane
-Regenerated configuration website isolation for users:
+Regenerated configuration CloudLinux Isolates for users:
 john
 jane
 ```
@@ -605,18 +605,18 @@ The `--user` option is only required when running as root.
 
 #### Common Issues
 
-**"Website isolation is not enabled"**
+**"CloudLinux Isolates is not enabled"**
 
 ```
 # Solution: Allow server-wide first
 cagefsctl --site-isolation-allow-all
 ```
 
-**"Website isolation feature is not available on this platform"**
+**"CloudLinux Isolates feature is not available on this platform"**
 
 The server does not have the required packages installed. Ensure all [prerequisite packages](#minimum-package-versions) are installed and up to date.
 
-**"Website isolation is not allowed for user \<username\>"**
+**"CloudLinux Isolates is not allowed for user \<username\>"**
 
 ```
 # Solution: Allow for the specific user


### PR DESCRIPTION
## Summary

Renames all remaining "Website isolation" strings to "CloudLinux Isolates" in CLI output code example blocks and troubleshooting section headings in the CloudLinux Isolates documentation (`docs/cloudlinuxos/isolates/README.md`).

This is a follow-up to the prose/heading renaming PR that was merged on 2026-04-02. The current PR addresses the CLI output strings that were intentionally left unchanged in the first PR because they document actual `cagefsctl` output.

**JIRA:** [CLOS-4108](https://cloudlinux.atlassian.net/browse/CLOS-4108)

## Changes (17 instances)

| # | Context | Old Output | New Output |
|---|---------|-----------|------------|
| 1 | `--site-isolation-allow-all` example | `Website isolation was allowed for all users.` | `CloudLinux Isolates was allowed for all users.` |
| 2 | `--site-isolation-deny-all` example | `Website isolation was denied for all users.` | `CloudLinux Isolates was denied for all users.` |
| 3-4 | `--site-isolation-allow` examples | `Website isolation was allowed for user(s): ...` | `CloudLinux Isolates was allowed for user(s): ...` |
| 5 | `--site-isolation-deny` example | `Website isolation was denied for user(s): john` | `CloudLinux Isolates was denied for user(s): john` |
| 6 | `--site-isolation-toggle-mode` example | `Website isolation user mode toggled to 'deny_all'.` | `CloudLinux Isolates user mode toggled to 'deny_all'.` |
| 7-8 | `--site-isolation-enable` examples | `Website isolation was enabled for domain(s), ...` | `CloudLinux Isolates was enabled for domain(s), ...` |
| 9 | `--site-isolation-disable` example | `Website isolation was disabled for domain(s), ...` | `CloudLinux Isolates was disabled for domain(s), ...` |
| 10-12 | `--site-isolation-list` examples | `Domains with enabled website isolation for user ...` | `Domains with enabled CloudLinux Isolates for user ...` |
| 13 | `--site-isolation-list` (empty) | `No users with enabled Website isolation` | `No users with enabled CloudLinux Isolates` |
| 14 | `--site-isolation-regenerate` example | `Regenerated configuration website isolation for users:` | `Regenerated configuration CloudLinux Isolates for users:` |
| 15 | Troubleshooting heading | `"Website isolation is not enabled"` | `"CloudLinux Isolates is not enabled"` |
| 16 | Troubleshooting heading | `"Website isolation feature is not available on this platform"` | `"CloudLinux Isolates feature is not available on this platform"` |
| 17 | Troubleshooting heading | `"Website isolation is not allowed for user <username>"` | `"CloudLinux Isolates is not allowed for user <username>"` |

## Notes

- CLI flag names (`--site-isolation-*`) are intentionally preserved for backward compatibility
- This PR is **blocked by** [CLOS-4109](https://cloudlinux.atlassian.net/browse/CLOS-4109) (the actual `cagefsctl` utility update) — the docs should only be merged after the utility outputs are updated
- Audit report: [Slite document](https://cloudlinux.slite.com/app/docs/Ub3Lpuw7gz1XK-)