### PR TITLE
STAR-71: Search drawer fixes — close on click + initial-load animation flash

### DIFF
--- a/docs/.vuepress/theme/drawer/Drawer.vue
+++ b/docs/.vuepress/theme/drawer/Drawer.vue
@@ -17,7 +17,7 @@
             <div class="drawer-main__breadcrumb">
               <!-- Optional breadcrumb can stay here -->
             </div>
-            <DrawerSearchResult :modelValue="modelValue" :data="drawerArticleResult"/>
+            <DrawerSearchResult :modelValue="modelValue" :data="drawerArticleResult" @closeDrawer="onCloseDrawer"/>
           </div>
         </div>
         <Footer v-if="isOpenDrawer && isMobileWidth" class="drawer-footer__mobile"/>

--- a/docs/.vuepress/theme/drawer/Drawer.vue
+++ b/docs/.vuepress/theme/drawer/Drawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="drawer" :class="{'is-open': isOpenDrawer}">
+    <div class="drawer" :class="{'is-open': isOpenDrawer, 'drawer--animated': animationsReady}">
       <div class="drawer-header">
         <div class="drawer-header__wrapper">
           <h2 class="drawer-header__paragraph">How can we help you?</h2>
@@ -30,7 +30,7 @@
 <script setup>
 import { withBase } from "@vuepress/client";
 import Footer from "../footer/Footer.vue";
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import DrawerSearchResult from "./DrawerSearchResult.vue";
 
 const props = defineProps({
@@ -66,6 +66,16 @@ const onCloseDrawer = () => {
   emit('closeDrawer');
 }
 
+// The drawer starts hidden (translateY(-100%)). Enabling the slide transition
+// only after the first paint prevents the close animation from flashing on
+// initial page load — it then fires only on genuine open/close toggles.
+const animationsReady = ref(false);
+onMounted(() => {
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    animationsReady.value = true;
+  }));
+});
+
 watch(() => props.isOpenDrawer, () => {
   document.body.classList.toggle('disable-scroll', props.isOpenDrawer);
 });
@@ -89,7 +99,12 @@ watch(() => props.isOpenDrawer, () => {
   background: $drawerHeaderBgColor
   opacity: 0;
   transform: translateY(-100%);
-  transition: 0.4s ease;
+
+  // Transition is intentionally NOT set here so the initial hidden state is
+  // applied instantly (no flash on first load). It is enabled via
+  // .drawer--animated once the component has mounted.
+  &.drawer--animated
+    transition: 0.4s ease
 
   &-header
     padding 1.25rem $layout-horizontal-padding

--- a/docs/.vuepress/theme/drawer/DrawerSearchResult.vue
+++ b/docs/.vuepress/theme/drawer/DrawerSearchResult.vue
@@ -61,7 +61,14 @@ const props = defineProps({
 const { MAX_VISIBLE_RESULT } = inject("themeConfig");
 const isShowAllResult = ref(false);
 
+const emit = defineEmits(["closeDrawer"]);
+
 const gotTo = (url) => {
+  // Always close the search drawer on click. When the target resolves to the
+  // page we are already on (same pathname, only the #hash differs) the browser
+  // does NOT reload, so the drawer would otherwise stay open over the page and
+  // the result would look unclickable (STAR-71).
+  emit("closeDrawer");
   const parsedCurrentUrl = new URL(window.location.href);
   if (parsedCurrentUrl.pathname + parsedCurrentUrl.hash === url) {
     window.location.reload();


### PR DESCRIPTION
This PR bundles two related search-drawer fixes (the second was folded in from a now-closed separate PR).

## 1. Search drawer not closing on click (STAR-71)

The search drawer was only torn down as a *side effect of a full page reload*. When a clicked result resolves to the page the user is already on — **same pathname, only the `#hash` differs** — `window.location.href` does **not** reload the page, so the drawer stayed open as an overlay while the content silently scrolled behind it, making the result look **unclickable**. Reproduced live on production via Playwright.

**Fix:** `DrawerSearchResult` emits `closeDrawer` on click; `Drawer` forwards it through the existing chain to `HeaderLayoutSearch.closeDrawer`. The drawer now closes on every navigation — full reload *or* hash-only.

## 2. Close-animation flash on initial page load

`.drawer` starts hidden (`translateY(-100%)`) but carried an unconditional `transition: 0.4s ease`, so the close animation could flash while the hidden state was applied during initial render.

**Fix:** the transition is gated behind a `.drawer--animated` class added only after mount (double `requestAnimationFrame`). Initial hidden state applies instantly (no flash); genuine open/close toggles still animate.

## Files
- `DrawerSearchResult.vue` — `defineEmits(["closeDrawer"])` + `emit("closeDrawer")` in `gotTo()`.
- `Drawer.vue` — `@closeDrawer` binding; `animationsReady` ref + `.drawer--animated` gating the transition.

## Verification (Playwright, local build)
Same-page click now closes the drawer; open and close both still animate; on fresh load the transition is absent until mount (no flash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)